### PR TITLE
Fix energy meter sensor reporting Wh values with a kWh unit (1000x too high)

### DIFF
--- a/custom_components/smarthq/sensor.py
+++ b/custom_components/smarthq/sensor.py
@@ -837,6 +837,21 @@ class SmartHQMeterSensor(SmartHQServiceSensor):
         )
 
     @property
+    def native_value(self):
+        st = self._get_state()
+        raw = st.get(self._state_key)
+        if raw is None:
+            return None
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            return raw
+        # API reports energy in Wh; convert to kWh when that is the unit
+        if self._attr_native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR:
+            return round(val / 1000, 3)
+        return val
+
+    @property
     def extra_state_attributes(self) -> dict:
         st = self._get_state()
         return {


### PR DESCRIPTION
```markdown
## Summary

Energy meter sensors report values that are **1000x too high** compared to the
SmartHQ mobile app. The raw value coming from the SmartHQ API is in
**Watt-hours (Wh)**, but the entity advertises its unit as **kilowatt-hours
(kWh)** without converting the value — so a reading that should be `12.345 kWh`
is displayed as `12345 kWh`.

Fixes #3

## Root cause

`SmartHQMeterSensor` inherited `native_value` from `SmartHQServiceSensor`, which
returns the raw `meterValue` from the WebSocket snapshot unchanged:

```python
@property
def native_value(self):
    st = self._get_state()
    return st.get(self._state_key)  # raw Wh value
```

Meanwhile the unit is mapped to kWh in `_meter_units_to_ha()` (when
`meterUnits == "kwh"`) and via the `METER_DOMAIN_UNIT_CLASS` fallback for
`cloud.smarthq.domain.energy`. The number was never divided by 1000, so the
magnitude and the unit disagreed.

## Fix

Override `native_value` in `SmartHQMeterSensor` to divide by 1000 when the unit
is kWh, converting the API's Wh value to the advertised unit:

```python
@property
def native_value(self):
    st = self._get_state()
    raw = st.get(self._state_key)
    if raw is None:
        return None
    try:
        val = float(raw)
    except (TypeError, ValueError):
        return raw
    # API reports energy in Wh; convert to kWh when that is the unit
    if self._attr_native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR:
        return round(val / 1000, 3)
    return val
```
## Testing

- `python -m py_compile custom_components/smarthq/sensor.py` passes.
- Standalone verification of the conversion logic:
  - `12345 Wh` → `12.345 kWh` (matches the 1000x correction in the issue)
  - both the `UnitOfEnergy.KILO_WATT_HOUR` enum and the `"kWh"` string match
  - a volts unit does **not** match and is not converted
- Note: the existing test suite (`test_config_flow.py`, `test_init.py`) requires
  the `homeassistant` package to import and does not cover meter sensors; it was
  not run as part of this change.

## Impact / notes

- Energy readings now match the SmartHQ app.
- Because this changes the reported magnitude of an existing sensor, users with
  long-term statistics may see a discontinuity in historical energy graphs at
  the upgrade point.
