### PR TITLE
docs: fix OAuth "User session expired" by requiring a unique app Machine name (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Before adding the integration, you need to obtain OAuth2 credentials from SmartH
 <img width="944" height="585" alt="image" src="https://github.com/user-attachments/assets/65e43b22-27cc-499d-bab4-097d6e0d70cb" />
 
 #### Step 2: Configure Your App
-1. Enter a **Machine name** (e.g., "homeassistant")
+1. Enter a **unique Machine name** (e.g., `homeassistant-yourname` or `ha-<something-unique>`)
+   > ⚠️ **Do NOT use the plain name `homeassistant`.** The Machine name must be globally unique on the SmartHQ Developer Portal. A name that is already taken (such as `homeassistant`) causes the OAuth login to fail with an `OAuth2.0 Error` / `User session expired` message. Pick your own unique name.
 2. Set **Callback URL** to: `https://my.home-assistant.io/redirect/oauth`
 3. Click **"ADD APP"**
 4. Copy your **Client ID** and **Client Secret** (you'll need these)
@@ -247,6 +248,14 @@ logger:
 ---
 
 ## Troubleshooting
+
+### "OAuth2.0 Error" / "User session expired. Please start over"
+This error usually comes from the SmartHQ (GE) OAuth server, not from Home Assistant. Check the following in order:
+1. **Use a unique app Machine name.** Do **not** name your app `homeassistant` on the [SmartHQ Developer Portal](https://developer.smarthq.com). A duplicate/reserved name causes this exact error. Delete the app and recreate it with a unique name (e.g., `homeassistant-yourname`), then create new Application Credentials in HA with a unique name too.
+2. **Verify the Callback URL** in the Developer Portal is exactly `https://my.home-assistant.io/redirect/oauth` (note the trailing `/oauth`).
+3. **Complete the login quickly.** The GE OAuth session has a short timeout — click the login link immediately and finish without leaving the tab open.
+4. If the GE page still says `User session expired`, clear cookies for `accounts.brillion.geappliances.com` (or use a private/incognito window) and click the link again to start a fresh session.
+5. Confirm you can sign in directly at [accounts.brillion.geappliances.com](https://accounts.brillion.geappliances.com/) with the same account.
 
 ### "Failed to authenticate"
 - Verify your Client ID and Client Secret are correct in Application Credentials


### PR DESCRIPTION
### Summary
Fixes the remaining `OAuth2.0 Error` / `User session expired. Please start over` reported in #2 after the v1.2.1 re-auth fixes.

The root cause was **not** in the integration code but in the setup instructions: the README recommended `homeassistant` as the app **Machine name** on the SmartHQ Developer Portal. That name is not globally unique, so users who copy-pasted it hit a name collision that caused GE's OAuth server to reject the authorization (`invalid_request` / `User session expired`).

Multiple users in #2 (@AlanEisen, @metatronc, @mcaulifn) independently confirmed that recreating the app with a **unique** Machine name resolves the error.

### Changes
- **README – Step 2 (Configure Your App):** replaced the `homeassistant` example with a requirement to use a **unique** Machine name, plus an explicit ⚠️ warning that a duplicate/reserved name (like plain `homeassistant`) triggers the OAuth error.
- **README – Troubleshooting:** added a new section `"OAuth2.0 Error" / "User session expired. Please start over"` covering:
  1. Use a unique app Machine name (recreate app + Application Credentials).
  2. Verify the Callback URL is exactly `https://my.home-assistant.io/redirect/oauth`.
  3. Complete the GE login quickly (short session timeout).
  4. Clear `accounts.brillion.geappliances.com` cookies / use incognito, then retry.
  5. Confirm direct sign-in at `accounts.brillion.geappliances.com`.

### Why docs-only
The app Machine name is chosen by the user in GE's Developer Portal and cannot be validated or controlled from the integration code. The v1.2.1 code fixes (re-auth flow + 401/403 surfacing) remain correct; this PR closes the documentation gap that kept steering new users into the failing configuration.

### Testing
- Verified README renders correctly (headings, code blocks, warning callout).
- No code changes; no functional/CI impact.

### Related
Closes #2 (pending final user confirmation).
