### PR TITLE
Fix: stop reloading the integration on hourly OAuth token refresh (entities flapping to unavailable)

### DIFF
--- a/custom_components/smarthq/__init__.py
+++ b/custom_components/smarthq/__init__.py
@@ -73,6 +73,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     bucket: Dict[str, Any] = {}
     hass.data[DOMAIN][entry.entry_id] = bucket
 
+    # Snapshot the current options so the update listener can distinguish a
+    # real options change (which needs a reload) from an entry.data change —
+    # e.g. the OAuth access token being refreshed ~hourly, which also fires
+    # update listeners and would otherwise reload the whole integration every
+    # hour and drop all entities to `unavailable`.
+    bucket["_last_options"] = dict(entry.options)
+
     # API
     from .api import SmartHQApi  # Lazy import
     api = SmartHQApi(hass, entry)
@@ -442,7 +449,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the entry when its options change."""
+    """Reload the entry only when its user-facing options actually change.
+
+    Update listeners fire on ANY config-entry update, including when HA's
+    OAuth2Session persists a freshly refreshed access token into entry.data
+    (~hourly). Reloading on those token refreshes tore down and rebuilt every
+    platform, briefly marking all entities `unavailable`. Compare the options
+    against the snapshot taken at setup and skip the reload when they're
+    unchanged (i.e. the update was a silent token refresh, not an options edit).
+    """
+    bucket = hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}
+    if bucket.get("_last_options") == dict(entry.options):
+        _LOGGER.debug(
+            "SmartHQ entry updated without an options change "
+            "(likely a token refresh); skipping reload"
+        )
+        return
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/smarthq/__init__.py
+++ b/custom_components/smarthq/__init__.py
@@ -73,13 +73,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     bucket: Dict[str, Any] = {}
     hass.data[DOMAIN][entry.entry_id] = bucket
 
-    # Snapshot the current options so the update listener can distinguish a
-    # real options change (which needs a reload) from an entry.data change —
-    # e.g. the OAuth access token being refreshed ~hourly, which also fires
-    # update listeners and would otherwise reload the whole integration every
-    # hour and drop all entities to `unavailable`.
-    bucket["_last_options"] = dict(entry.options)
-
     # API
     from .api import SmartHQApi  # Lazy import
     api = SmartHQApi(hass, entry)
@@ -440,32 +433,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Assistant convenience layer (entity exposure + optional Telegram bridge).
     await _async_setup_messaging(hass, entry, bucket)
 
-    # Reload this entry whenever its options change so the messaging layer
-    # reflects the new settings.
+    # Reload this entry only when its user-facing options actually change so the
+    # messaging layer reflects the new settings.
+    #
+    # Update listeners fire on ANY config-entry update, including when HA's
+    # OAuth2Session persists a freshly refreshed access token into entry.data
+    # (~hourly). Reloading on those token refreshes tore down and rebuilt every
+    # platform, briefly marking all entities `unavailable`. Capture the current
+    # options in a closure and skip the reload when they're unchanged (i.e. the
+    # update was a silent token refresh, not an options edit). The closure is
+    # scoped to this async_setup_entry call, so after a reload the new setup
+    # naturally starts with fresh options — no stale state possible.
+    _last_options: dict = dict(entry.options)
+
+    async def _async_options_updated(
+        hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        nonlocal _last_options
+        if dict(entry.options) == _last_options:
+            _LOGGER.debug(
+                "SmartHQ entry updated without an options change "
+                "(likely a token refresh); skipping reload"
+            )
+            return
+        _last_options = dict(entry.options)
+        await hass.config_entries.async_reload(entry.entry_id)
+
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
     _LOGGER.info("SmartHQ setup complete (devices=%d)", len(store))
     return True
-
-
-async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload the entry only when its user-facing options actually change.
-
-    Update listeners fire on ANY config-entry update, including when HA's
-    OAuth2Session persists a freshly refreshed access token into entry.data
-    (~hourly). Reloading on those token refreshes tore down and rebuilt every
-    platform, briefly marking all entities `unavailable`. Compare the options
-    against the snapshot taken at setup and skip the reload when they're
-    unchanged (i.e. the update was a silent token refresh, not an options edit).
-    """
-    bucket = hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}
-    if bucket.get("_last_options") == dict(entry.options):
-        _LOGGER.debug(
-            "SmartHQ entry updated without an options change "
-            "(likely a token refresh); skipping reload"
-        )
-        return
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def _async_setup_messaging(


### PR DESCRIPTION
## Summary

All SmartHQ entities briefly go `unavailable` on a fixed ~1-hour cadence, even when the appliance is online and nothing about the account or configuration has changed. This PR fixes the root cause: the integration reloads its own config entry every time the OAuth access token is refreshed.

## Root cause

`async_setup_entry` registers an options update listener:

```python
entry.async_on_unload(entry.add_update_listener(_async_options_updated))

async def _async_options_updated(hass, entry):
    """Reload the entry when its options change."""
    await hass.config_entries.async_reload(entry.entry_id)
```

Config-entry update listeners fire on **any** update to the entry — not just options changes. Home Assistant's `OAuth2Session.async_ensure_token_valid()` persists the newly refreshed token by calling `async_update_entry(entry, data=...)`. SmartHQ access tokens have roughly a one-hour lifetime, so this write happens about once an hour (it is triggered lazily by the next authenticated request, e.g. the websocket re-endpoint fetch after the cloud drops the token-bearing socket).

Because the listener does not distinguish a token write (`entry.data`) from a real options change (`entry.options`), each hourly token refresh calls `async_reload()`, which tears down and rebuilds every platform. During that reload window all entities for the device report `unavailable` for a few seconds before the entry finishes reloading.

### Observed symptoms

- Every SmartHQ entity on the device drops to `unavailable` together, roughly hourly, then recovers a few seconds later.
- The drop window drifts by a few seconds each cycle, matching the token TTL rather than a wall-clock schedule.
- A `homeassistant.loader` "We found a custom integration smarthq which has not been tested…" line is logged at each drop, i.e. the integration module is being re-imported as part of a reload.

The token refresh itself is fine and already silent — it is the unconditional reload wired to it that causes the outage.

## Fix

Only reload when the user-facing **options** actually change. Snapshot `entry.options` at setup and compare against it in the listener; skip the reload when the options are unchanged (i.e. the update was a token-only `entry.data` write). Real options edits still trigger a reload exactly as before.

```python
# in async_setup_entry
bucket["_last_options"] = dict(entry.options)

async def _async_options_updated(hass, entry):
    bucket = hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}
    if bucket.get("_last_options") == dict(entry.options):
        # token refresh (entry.data changed), not an options edit — no reload
        return
    await hass.config_entries.async_reload(entry.entry_id)
```

## Behavior change

- **Before:** integration reloads ~hourly on every token refresh; all entities blip `unavailable`.
- **After:** token refreshes are ignored by the listener; the websocket reconnects transparently in the background and entities keep their last-known state. Options changes still reload the entry.

## Testing

- Verified the guard skips the reload on token-only updates and still reloads on an options change.
- `python -m py_compile custom_components/smarthq/__init__.py` passes.
- Confirmed against the live symptom: the recurring hourly `unavailable` transitions on the climate entity align exactly with token-refresh cycles, and no config or option changes occur across them.

## Scope

Single-file change to `custom_components/smarthq/__init__.py`. No changes to the OAuth flow, the websocket client, or entity logic.
