### PR TITLE
Fix: report climate current_temperature from the sibling temperature service (was always unknown)

### DIFF
--- a/custom_components/smarthq/climate.py
+++ b/custom_components/smarthq/climate.py
@@ -264,7 +264,7 @@ class SmartHQThermostatClimate(ClimateEntity):
             except (TypeError, ValueError):
                 continue
             dom = (svc.get("domainType") or "").lower()
-            if "measurement" in dom or "early" in dom or "ambient" in dom:
+            if "measurement" in dom or "ambient" in dom:
                 preferred = val
                 break
             if fallback is None:

--- a/custom_components/smarthq/climate.py
+++ b/custom_components/smarthq/climate.py
@@ -32,6 +32,7 @@ from .const import DOMAIN, MANUFACTURER, DEFAULT_NAME
 from .dispatcher import SIGNAL_DEVICE_UPDATED
 from .service_registry import (
     THERMOSTAT_SERVICE,
+    TEMPERATURE_SERVICE,
     get_device_services,
     make_unique_id,
     get_service_mapping,
@@ -241,8 +242,34 @@ class SmartHQThermostatClimate(ClimateEntity):
 
     @property
     def current_temperature(self) -> float | None:
-        # thermostat.v1 doesn't expose a measured temperature field in state
-        return None
+        # thermostat.v1 doesn't expose a measured temperature field, but the
+        # same device typically publishes a sibling `service.temperature`
+        # service with a `fahrenheit` reading (surfaced as the "Ambient
+        # Temperature (°F)" sensor). Pull from there so Apple Home / the HA
+        # thermostat card show the actual room temp instead of "unknown".
+        snap = _store(self.hass, self._entry).get(self._device_id) or {}
+        services = (snap.get("snapshot") or {}).get("services") or {}
+        preferred: float | None = None
+        fallback: float | None = None
+        for sid, svc in services.items():
+            if sid == self._service_id:
+                continue
+            if (svc.get("serviceType") or "") != TEMPERATURE_SERVICE:
+                continue
+            raw = svc.get("fahrenheit")
+            if raw is None:
+                continue
+            try:
+                val = float(raw)
+            except (TypeError, ValueError):
+                continue
+            dom = (svc.get("domainType") or "").lower()
+            if "measurement" in dom or "early" in dom or "ambient" in dom:
+                preferred = val
+                break
+            if fallback is None:
+                fallback = val
+        return preferred if preferred is not None else fallback
 
     @property
     def target_temperature(self) -> float | None:


### PR DESCRIPTION
## Summary

The climate entity for SmartHQ AC/thermostat appliances never reported a current temperature: the HA thermostat card — and Apple Home, when the entity is bridged over HomeKit — showed `unknown` for the room temperature, even though the appliance publishes the reading.

## Root cause

`SmartHQThermostatClimate.current_temperature` was a hard-coded stub:

```python
@property
def current_temperature(self) -> float | None:
    # thermostat.v1 doesn't expose a measured temperature field in state
    return None
```

The `cloud.smarthq.service.thermostat.v1` service genuinely does not carry a measured temperature in its state, so there is nothing to read there. However, these appliances expose a **sibling** `cloud.smarthq.service.temperature` service on the same device that carries a `fahrenheit` value — the same reading the integration already surfaces as the "Ambient Temperature (°F)" sensor. The climate entity simply wasn't consulting it.

## Fix

Read `current_temperature` from the sibling temperature service on the same device:

- Iterate the device's services and select the `TEMPERATURE_SERVICE` (`cloud.smarthq.service.temperature`) entry, skipping the thermostat's own service id.
- Prefer a reading whose `domainType` looks like a measurement/ambient value; fall back to the first available temperature service otherwise.
- Guard against missing or non-numeric `fahrenheit` values so a malformed reading returns `None`/falls back rather than raising.

```python
@property
def current_temperature(self) -> float | None:
    snap = _store(self.hass, self._entry).get(self._device_id) or {}
    services = (snap.get("snapshot") or {}).get("services") or {}
    preferred: float | None = None
    fallback: float | None = None
    for sid, svc in services.items():
        if sid == self._service_id:
            continue
        if (svc.get("serviceType") or "") != TEMPERATURE_SERVICE:
            continue
        raw = svc.get("fahrenheit")
        if raw is None:
            continue
        try:
            val = float(raw)
        except (TypeError, ValueError):
            continue
        dom = (svc.get("domainType") or "").lower()
        if "measurement" in dom or "early" in dom or "ambient" in dom:
            preferred = val
            break
        if fallback is None:
            fallback = val
    return preferred if preferred is not None else fallback
```

`TEMPERATURE_SERVICE` is already defined in `service_registry.py` (`cloud.smarthq.service.temperature`); this change just imports and uses it.

## Behavior change

- **Before:** the thermostat card / Apple Home show `unknown` for current temperature; `current_temperature` is always `None`.
- **After:** the climate entity reports the appliance's ambient temperature, matching the existing "Ambient Temperature (°F)" sensor. Devices with no sibling temperature service are unchanged (still `None`).

## Testing

- Verified on an AC appliance that publishes a sibling `cloud.smarthq.service.temperature` service: the climate entity now reports the same value as the ambient temperature sensor, and the HA thermostat card shows the room temperature.
- Confirmed the guards return `None` cleanly when no temperature service or no numeric reading is present.
- `python -m py_compile custom_components/smarthq/climate.py` passes.

## Scope

Single-file change to `custom_components/smarthq/climate.py` (one import + the `current_temperature` property). No changes to the temperature sensor platform, the websocket client, or command handling.
