### PR TITLE
docs: sync shipped component README with root README (HACS-delivered docs)

### DIFF
--- a/custom_components/smarthq/README.md
+++ b/custom_components/smarthq/README.md
@@ -55,7 +55,18 @@ This means **no hardcoded device support is needed** — any appliance commissio
 
 ## Installation
 
-### 1. Install the Integration
+### Option A: Install via HACS (Recommended)
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=geappliances&repository=geappliances-smarthq-integration&category=integration)
+
+1. Click the button above — your Home Assistant will open the HACS custom repository dialog automatically
+2. Click **"Download"** to install the integration
+3. Restart Home Assistant
+
+> **Don't have HACS?** Install it from [hacs.xyz](https://hacs.xyz/docs/use/download/download/) first, then return here.
+
+### Option B: Manual Installation
+
 Copy this folder to your Home Assistant configuration directory:
 ```bash
 /config/custom_components/smarthq
@@ -76,7 +87,8 @@ Before adding the integration, you need to obtain OAuth2 credentials from SmartH
 <img width="944" height="585" alt="image" src="https://github.com/user-attachments/assets/65e43b22-27cc-499d-bab4-097d6e0d70cb" />
 
 #### Step 2: Configure Your App
-1. Enter a **Machine name** (e.g., "homeassistant")
+1. Enter a **unique Machine name** (e.g., `homeassistant-yourname` or `ha-<something-unique>`)
+   > ⚠️ **Do NOT use the plain name `homeassistant`.** The Machine name must be globally unique on the SmartHQ Developer Portal. A name that is already taken (such as `homeassistant`) causes the OAuth login to fail with an `OAuth2.0 Error` / `User session expired` message. Pick your own unique name.
 2. Set **Callback URL** to: `https://my.home-assistant.io/redirect/oauth`
 3. Click **"ADD APP"**
 4. Copy your **Client ID** and **Client Secret** (you'll need these)
@@ -236,6 +248,14 @@ logger:
 ---
 
 ## Troubleshooting
+
+### "OAuth2.0 Error" / "User session expired. Please start over"
+This error usually comes from the SmartHQ (GE) OAuth server, not from Home Assistant. Check the following in order:
+1. **Use a unique app Machine name.** Do **not** name your app `homeassistant` on the [SmartHQ Developer Portal](https://developer.smarthq.com). A duplicate/reserved name causes this exact error. Delete the app and recreate it with a unique name (e.g., `homeassistant-yourname`), then create new Application Credentials in HA with a unique name too.
+2. **Verify the Callback URL** in the Developer Portal is exactly `https://my.home-assistant.io/redirect/oauth` (note the trailing `/oauth`).
+3. **Complete the login quickly.** The GE OAuth session has a short timeout — click the login link immediately and finish without leaving the tab open.
+4. If the GE page still says `User session expired`, clear cookies for `accounts.brillion.geappliances.com` (or use a private/incognito window) and click the link again to start a fresh session.
+5. Confirm you can sign in directly at [accounts.brillion.geappliances.com](https://accounts.brillion.geappliances.com/) with the same account.
 
 ### "Failed to authenticate"
 - Verify your Client ID and Client Secret are correct in Application Credentials


### PR DESCRIPTION
### Summary
Follow-up to #11. That PR fixed the **root** `README.md`, but the README that HACS actually ships to users — `custom_components/smarthq/README.md` — had diverged and did **not** receive the fix.

This PR makes the shipped component README identical to the root README so there is a single canonical source and HACS delivers correct, complete docs.

### What was out of sync in `custom_components/smarthq/README.md`
- Missing the **HACS install instructions** (Option A / Option B) that the root README has.
- Missing the OAuth **"unique Machine name"** fix and the `"OAuth2.0 Error" / "User session expired"` troubleshooting section from #11.

### Change
- `custom_components/smarthq/README.md` → made identical to root `README.md`.

### Why it matters
HACS copies `custom_components/smarthq/` to users' installs. Without this, users would keep seeing the outdated instructions (including the `homeassistant` app-name pitfall from #2) even after #11.

### Related
Refs #2, follows #11.