### PR TITLE
fix: reduce settings poll interval 30 s → 10 min to cut API traffic

### DIFF
--- a/custom_components/smarthq/__init__.py
+++ b/custom_components/smarthq/__init__.py
@@ -160,14 +160,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Optional: provide 'ws' alias for legacy code compatibility
     bucket["ws"] = ws
     
-    # Settings polling task (every 30 seconds)
+    # Settings polling task
+    # Interval: 10 minutes. The SmartHQ WebSocket does not push device#setting
+    # events, so REST polling is required to catch changes made via the mobile
+    # app. 10 min is sufficient for low-frequency notification/alert toggles
+    # and reduces API traffic by ~95 % compared to the previous 30-second cadence.
+    _SETTINGS_POLL_INTERVAL = 600  # seconds
     async def _poll_settings():
-        """Poll settings every 30 seconds since WebSocket doesn't update them."""
+        """Poll device settings periodically since WebSocket doesn't push them."""
         from .dispatcher import SIGNAL_DEVICE_UPDATED
         from homeassistant.helpers.dispatcher import async_dispatcher_send
-        
+
         while True:
-            await asyncio.sleep(30)
+            await asyncio.sleep(_SETTINGS_POLL_INTERVAL)
             try:
                 for device_id in list(store.keys()):
                     try:


### PR DESCRIPTION
### Problem
The cloud team reported anomalously high API traffic from Home Assistant — 30,000+ requests/day per installation.

Root cause: the settings polling task in \`async_setup_entry\` runs every **30 seconds** and issues **1 + N HTTP requests per device per cycle** (one summary call to \`/v2/device/{id}/setting\` plus one detail call to \`/v2/device/{id}/setting/{rule_id}\` for each setting rule). For a typical appliance with ~10 setting rules this yields **~31,000 requests/device/day**.

### Why polling is necessary
The SmartHQ WebSocket does **not** push \`device#setting\` events. This was verified by adding a \`WARNING\`-level log entry (\`[SETTING_RECV]\`) to the WS message handler and changing a notification toggle in the SmartHQ app — no log entry appeared. REST polling is therefore the only mechanism to reflect changes made via the mobile app.

### Fix
Change the poll interval from **30 s → 600 s (10 min)**.

Setting switches (\`SmartHQSettingSwitch\`) back notification/alert toggles (door alert, preheat complete, filter reminder, …). These are \`EntityCategory.CONFIG\` entities — low-frequency, non-time-critical. A 10-minute staleness window is acceptable.

**HA-side changes are unaffected**: toggling a switch from HA updates the store optimistically and immediately via the existing \`_update_store()\` path, independent of the poll cycle.

### Traffic impact

| Interval | Requests/device/day (10 settings) |
|---|---|
| 30 s (before) | ~31,680 |
| 600 s (after) | ~1,584 |
| **Reduction** | **~95 %** |

### Changes
- \`custom_components/smarthq/__init__.py\`: \`asyncio.sleep(30)\` → \`asyncio.sleep(_SETTINGS_POLL_INTERVAL)\` where \`_SETTINGS_POLL_INTERVAL = 600\`