### PR TITLE
docs: add Known Limitations section (Oven, Advantium, F&P, Cooktops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ This integration uses **OAuth2 Application Credentials** with Authorization Code
 
 ---
 
+## Current Limitations
+
+This integration is built exclusively on the **SmartHQ v2 public developer API**. The SmartHQ mobile app communicates over GE's internal v1 API, which exposes capabilities not available through the public v2 path. As a result, some product lines have limited or no support in Home Assistant even when the app shows full control:
+
+| Product Line | Status | Notes |
+|---|---|---|
+| **Oven / Wall Oven / Range** | ⚠️ Limited | Only basic toggles (Sabbath, Control Lock) and notification settings are available. Cooking features (cavity temperature, cooking mode, cook time, remote start) are served via the app's internal API and are not yet exposed through the v2 public API. The App & Cloud team is actively working to expand oven support. |
+| **Advantium (Speed Cook Oven)** | ❌ Not supported | The Advantium device has no appliance-specific services registered in the v2 API. Only common services (firmware, RSSI, etc.) may appear. |
+| **Fisher & Paykel appliances** | ❌ Not supported | Fisher & Paykel products are not documented in the SmartHQ v2 public developer API and are not compatible with this integration. |
+| **Electric / Gas / Induction Cooktops** | ⚠️ Limited | Active cooktop control features may not be exposed through the v2 API. Basic status and settings entities may appear. |
+
+> If your appliance connects successfully but shows fewer entities than expected, the most likely cause is that the cooking or control services for your specific model are not yet exposed through the v2 public developer API — not a bug in the integration.
+
+---
+
 ## How It Works — Service-Based Entity Discovery
 
 This integration is built on the **SmartHQ Developer Portal Cloud API**, which exposes each appliance's capabilities as a list of **Services**. Every SmartHQ device commissioning declares which services it supports (e.g. `cooking.mode.v1`, `laundry.state.v1`, `toggle`, `meter`, etc.).

--- a/custom_components/smarthq/README.md
+++ b/custom_components/smarthq/README.md
@@ -15,6 +15,21 @@ This integration uses **OAuth2 Application Credentials** with Authorization Code
 
 ---
 
+## Current Limitations
+
+This integration is built exclusively on the **SmartHQ v2 public developer API**. The SmartHQ mobile app communicates over GE's internal v1 API, which exposes capabilities not available through the public v2 path. As a result, some product lines have limited or no support in Home Assistant even when the app shows full control:
+
+| Product Line | Status | Notes |
+|---|---|---|
+| **Oven / Wall Oven / Range** | ⚠️ Limited | Only basic toggles (Sabbath, Control Lock) and notification settings are available. Cooking features (cavity temperature, cooking mode, cook time, remote start) are served via the app's internal API and are not yet exposed through the v2 public API. The App & Cloud team is actively working to expand oven support. |
+| **Advantium (Speed Cook Oven)** | ❌ Not supported | The Advantium device has no appliance-specific services registered in the v2 API. Only common services (firmware, RSSI, etc.) may appear. |
+| **Fisher & Paykel appliances** | ❌ Not supported | Fisher & Paykel products are not documented in the SmartHQ v2 public developer API and are not compatible with this integration. |
+| **Electric / Gas / Induction Cooktops** | ⚠️ Limited | Active cooktop control features may not be exposed through the v2 API. Basic status and settings entities may appear. |
+
+> If your appliance connects successfully but shows fewer entities than expected, the most likely cause is that the cooking or control services for your specific model are not yet exposed through the v2 public developer API — not a bug in the integration.
+
+---
+
 ## How It Works — Service-Based Entity Discovery
 
 This integration is built on the **SmartHQ Developer Portal Cloud API**, which exposes each appliance's capabilities as a list of **Services**. Every SmartHQ device commissioning declares which services it supports (e.g. `cooking.mode.v1`, `laundry.state.v1`, `toggle`, `meter`, etc.).


### PR DESCRIPTION
### Summary
Adds a **Current Limitations** section near the top of the README (and the HACS-delivered `custom_components/smarthq/README.md`) to proactively document product lines that have limited or no support in Home Assistant — preventing recurring bug reports from users who see fewer entities than the SmartHQ app shows.

### Background
This integration is built exclusively on the **SmartHQ v2 public developer API**. The SmartHQ mobile app uses GE's internal v1 API, which exposes capabilities not available through the v2 path. Confirmed via the [SmartHQ developer docs](https://docs.smarthq.com):

| Product Line | v2 API Status | Basis |
|---|---|---|
| **Oven / Wall Oven / Range** | Only Sabbath toggle + common services listed | [docs.smarthq.com/data-model/devices/oven](https://docs.smarthq.com/data-model/devices/oven/) |
| **Advantium** | Common services only — no device-specific services | [docs.smarthq.com/data-model/devices/advantium](https://docs.smarthq.com/data-model/devices/advantium/) |
| **Fisher & Paykel** | Not in SmartHQ v2 docs at all | N/A |
| **Electric / Gas / Induction Cooktops** | Active control services not confirmed in v2 | Docs reviewed |

### Changes
- `README.md` (root): added `## Current Limitations` section between the intro paragraph and `## How It Works`
- `custom_components/smarthq/README.md` (HACS-delivered): identical change applied so both files stay in sync

### Related
Prompted by issue #17 (Oven / JTS3000DN2WW: no cooking entities) and recurring similar reports.