### PR TITLE
chore: bump manifest version to 1.2.3

### DIFF
--- a/custom_components/smarthq/manifest.json
+++ b/custom_components/smarthq/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/geappliances/geappliances-smarthq-integration/issues",
   "loggers": ["custom_components.smarthq"],
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
Single-line change: `"version": "1.2.2"` → `"version": "1.2.3"` in `manifest.json`. Required for HACS to surface the v1.2.3 update notification.