### PR TITLE
docs: extend Known Limitations note to Fisher & Paykel / Haier appliances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This integration is built exclusively on the **SmartHQ v2 public developer API**
 |---|---|---|
 | **Oven / Wall Oven / Range** | ⚠️ Limited | Only basic toggles (Sabbath, Control Lock) and notification settings are available. Cooking features (cavity temperature, cooking mode, cook time, remote start) are served via the app's internal API and are not yet exposed through the v2 public API. The App & Cloud team is actively working to expand oven support. |
 | **Advantium (Speed Cook Oven)** | ❌ Not supported | The Advantium device has no appliance-specific services registered in the v2 API. Only common services (firmware, RSSI, etc.) may appear. |
-| **Fisher & Paykel appliances** | ❌ Not supported | Fisher & Paykel products are not documented in the SmartHQ v2 public developer API and are not compatible with this integration. |
+| **Fisher & Paykel / Haier appliances** | ⚠️ Limited / ❌ Not supported | These brands use the same SmartHQ Cloud and mobile app as GE Appliances, but appear not to be fully migrated to the SmartHQ v2 public developer API yet. Depending on the model, this can mean missing readings (e.g., current temperature) or no device-specific services being exposed at all. |
 | **Electric / Gas / Induction Cooktops** | ⚠️ Limited | Active cooktop control features may not be exposed through the v2 API. Basic status and settings entities may appear. |
 
 > If your appliance connects successfully but shows fewer entities than expected, the most likely cause is that the cooking or control services for your specific model are not yet exposed through the v2 public developer API — not a bug in the integration.

--- a/custom_components/smarthq/README.md
+++ b/custom_components/smarthq/README.md
@@ -23,7 +23,7 @@ This integration is built exclusively on the **SmartHQ v2 public developer API**
 |---|---|---|
 | **Oven / Wall Oven / Range** | ⚠️ Limited | Only basic toggles (Sabbath, Control Lock) and notification settings are available. Cooking features (cavity temperature, cooking mode, cook time, remote start) are served via the app's internal API and are not yet exposed through the v2 public API. The App & Cloud team is actively working to expand oven support. |
 | **Advantium (Speed Cook Oven)** | ❌ Not supported | The Advantium device has no appliance-specific services registered in the v2 API. Only common services (firmware, RSSI, etc.) may appear. |
-| **Fisher & Paykel appliances** | ❌ Not supported | Fisher & Paykel products are not documented in the SmartHQ v2 public developer API and are not compatible with this integration. |
+| **Fisher & Paykel / Haier appliances** | ⚠️ Limited / ❌ Not supported | These brands use the same SmartHQ Cloud and mobile app as GE Appliances, but appear not to be fully migrated to the SmartHQ v2 public developer API yet. Depending on the model, this can mean missing readings (e.g., current temperature) or no device-specific services being exposed at all. |
 | **Electric / Gas / Induction Cooktops** | ⚠️ Limited | Active cooktop control features may not be exposed through the v2 API. Basic status and settings entities may appear. |
 
 > If your appliance connects successfully but shows fewer entities than expected, the most likely cause is that the cooking or control services for your specific model are not yet exposed through the v2 public developer API — not a bug in the integration.


### PR DESCRIPTION
### Summary
Extends the README's **Current Limitations** section (added in #18) to cover Haier appliances alongside Fisher & Paykel, based on issue #20.

### Background
Issue #20 reports that a Haier HP330M1U1 heat pump water heater shows `current_temperature: null` in the `water_heater` entity, even though the SmartHQ app displays it.

Checked against the [SmartHQ v2 Water Heater device spec](https://docs.smarthq.com/data-model/devices/water-heater/): there is **no measured/current-temperature service defined at all** for the Water Heater device in the v2 public API (only Boost, Cost of Power, Cycle Timer, Hot Water remaining, Timeout, Voltage/Amperage meters, and the `waterheater.v1` control service). This isn't a mapping bug in the integration — the data simply isn't available through v2 for this device.

This matches the same pattern already documented for Fisher & Paykel: the brand appears not to be fully migrated to the SmartHQ v2 public API yet, while the mobile app (GE's internal v1 API) has access to more data.

### Changes
- Merged the Fisher & Paykel row into a combined **Fisher & Paykel / Haier appliances** row in both `README.md` and `custom_components/smarthq/README.md`.

### Related
Refs #20.