### PR TITLE
fix(climate): expose Energy Saver as AUTO and report activity

### DIFF
--- a/custom_components/smarthq/climate.py
+++ b/custom_components/smarthq/climate.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.climate.const import (
@@ -31,6 +32,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, MANUFACTURER, DEFAULT_NAME
 from .dispatcher import SIGNAL_DEVICE_UPDATED
 from .service_registry import (
+    POWER_USAGE_SERVICE,
     THERMOSTAT_SERVICE,
     TEMPERATURE_SERVICE,
     get_device_services,
@@ -41,16 +43,20 @@ from .service_registry import (
 
 _LOGGER = logging.getLogger(__name__)
 
+_COMPRESSOR_POWER_THRESHOLD_W = 120.0
+_ENERGY_SAVER_MODE = "cloud.smarthq.type.thermostatmode.cool.energysaver"
+_NATIVE_AUTO_MODE = "cloud.smarthq.type.thermostatmode.auto"
+
 # ---------------------------------------------------------------------------
 # SmartHQ → HA HVAC mode mapping
 # ---------------------------------------------------------------------------
 _THERMOSTAT_MODE_MAP: Dict[str, HVACMode] = {
     "cloud.smarthq.type.thermostatmode.cool":              HVACMode.COOL,
-    "cloud.smarthq.type.thermostatmode.cool.energysaver":  HVACMode.COOL,
+    _ENERGY_SAVER_MODE:                                    HVACMode.AUTO,
     "cloud.smarthq.type.thermostatmode.cool.quiet":        HVACMode.COOL,
     "cloud.smarthq.type.thermostatmode.cool.turbo":        HVACMode.COOL,
     "cloud.smarthq.type.thermostatmode.heat":              HVACMode.HEAT,
-    "cloud.smarthq.type.thermostatmode.auto":              HVACMode.AUTO,
+    _NATIVE_AUTO_MODE:                                     HVACMode.AUTO,
     "cloud.smarthq.type.thermostatmode.auto.twotemperature": HVACMode.AUTO,
     "cloud.smarthq.type.thermostatmode.dry":               HVACMode.DRY,
     "cloud.smarthq.type.thermostatmode.fanonly":           HVACMode.FAN_ONLY,
@@ -63,7 +69,7 @@ _THERMOSTAT_MODE_MAP: Dict[str, HVACMode] = {
 _HA_MODE_TO_SMARTHQ: Dict[HVACMode, str] = {
     HVACMode.COOL:     "cloud.smarthq.type.thermostatmode.cool",
     HVACMode.HEAT:     "cloud.smarthq.type.thermostatmode.heat",
-    HVACMode.AUTO:     "cloud.smarthq.type.thermostatmode.auto",
+    HVACMode.AUTO:     _NATIVE_AUTO_MODE,
     HVACMode.DRY:      "cloud.smarthq.type.thermostatmode.dry",
     HVACMode.FAN_ONLY: "cloud.smarthq.type.thermostatmode.fanonly",
     HVACMode.OFF:      "cloud.smarthq.type.thermostatmode.off",
@@ -200,9 +206,9 @@ class SmartHQThermostatClimate(ClimateEntity):
         self._attr_unique_id = unique_id
 
         # Build supported HVAC modes from config
-        supported_modes_tokens = svc_config.get("supportedModes") or []
+        self._supported_mode_tokens = set(svc_config.get("supportedModes") or [])
         hvac_modes = {HVACMode.OFF}
-        for token in supported_modes_tokens:
+        for token in self._supported_mode_tokens:
             ha_mode = _THERMOSTAT_MODE_MAP.get(token)
             if ha_mode:
                 hvac_modes.add(ha_mode)
@@ -239,6 +245,56 @@ class SmartHQThermostatClimate(ClimateEntity):
             return HVACMode.OFF
         mode_token = st.get("mode") or ""
         return _THERMOSTAT_MODE_MAP.get(mode_token, HVACMode.OFF)
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the unit's current activity."""
+        st = self._get_state()
+        if st.get("on", True) is False:
+            return HVACAction.OFF
+
+        mode = self.hvac_mode
+        if mode == HVACMode.OFF:
+            return HVACAction.OFF
+        if mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+
+        running = self._compressor_running()
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING if running else HVACAction.IDLE
+        if mode == HVACMode.DRY:
+            return HVACAction.DRYING if running else HVACAction.IDLE
+        return HVACAction.COOLING if running else HVACAction.IDLE
+
+    def _instantaneous_power(self) -> float | None:
+        """Return live power draw from the sibling power service."""
+        snap = _store(self.hass, self._entry).get(self._device_id) or {}
+        services = (snap.get("snapshot") or {}).get("services") or {}
+        for svc in services.values():
+            if (svc.get("serviceType") or "") != POWER_USAGE_SERVICE:
+                continue
+            raw = svc.get("instantaneousPower")
+            if raw is None:
+                continue
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _compressor_running(self) -> bool:
+        """Infer compressor activity from power or current temperature."""
+        power = self._instantaneous_power()
+        if power is not None:
+            return power > _COMPRESSOR_POWER_THRESHOLD_W
+
+        current = self.current_temperature
+        target = self.target_temperature
+        if current is None or target is None:
+            return True
+        if self.hvac_mode == HVACMode.HEAT:
+            return current < target
+        return current > target
 
     @property
     def current_temperature(self) -> float | None:
@@ -310,6 +366,12 @@ class SmartHQThermostatClimate(ClimateEntity):
             await client.async_set_thermostat(self._device_id, self._service_id, on=False)
         else:
             smarthq_mode = _HA_MODE_TO_SMARTHQ.get(hvac_mode)
+            if (
+                hvac_mode == HVACMode.AUTO
+                and _ENERGY_SAVER_MODE in self._supported_mode_tokens
+                and _NATIVE_AUTO_MODE not in self._supported_mode_tokens
+            ):
+                smarthq_mode = _ENERGY_SAVER_MODE
             if smarthq_mode:
                 await client.async_set_thermostat(
                     self._device_id, self._service_id,

--- a/custom_components/smarthq/tests/test_climate.py
+++ b/custom_components/smarthq/tests/test_climate.py
@@ -1,0 +1,114 @@
+"""Tests for the SmartHQ climate platform."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.climate import HVACAction, HVACMode
+
+from custom_components.smarthq.climate import SmartHQThermostatClimate
+from custom_components.smarthq.const import DOMAIN
+from custom_components.smarthq.service_registry import POWER_USAGE_SERVICE
+
+ENERGY_SAVER_MODE = "cloud.smarthq.type.thermostatmode.cool.energysaver"
+NATIVE_AUTO_MODE = "cloud.smarthq.type.thermostatmode.auto"
+
+
+def _create_entity(*supported_modes: str) -> tuple[SmartHQThermostatClimate, AsyncMock]:
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"test-entry": {"store": {}}}}
+    entry = MagicMock()
+    entry.entry_id = "test-entry"
+    client = AsyncMock()
+    entity = SmartHQThermostatClimate(
+        hass=hass,
+        entry=entry,
+        client=client,
+        device_id="test-device",
+        service_id="test-thermostat",
+        dev_name="Test AC",
+        svc_config={"supportedModes": list(supported_modes)},
+        unique_id="test-climate",
+    )
+    return entity, client
+
+
+def _set_thermostat_state(
+    entity: SmartHQThermostatClimate,
+    *,
+    on: bool = True,
+    mode: str,
+    power: float | None = None,
+) -> None:
+    services = {"test-thermostat": {"on": on, "mode": mode}}
+    if power is not None:
+        services["power"] = {
+            "serviceType": POWER_USAGE_SERVICE,
+            "instantaneousPower": power,
+        }
+    entity.hass.data[DOMAIN]["test-entry"]["store"] = {
+        "test-device": {"snapshot": {"services": services}}
+    }
+
+
+def test_energy_saver_is_exposed_and_set_as_auto() -> None:
+    """Expose an eco-only appliance as AUTO and send its supported token."""
+    entity, client = _create_entity(ENERGY_SAVER_MODE)
+    entity.hass.data[DOMAIN]["test-entry"]["store"] = {
+        "test-device": {
+            "snapshot": {
+                "services": {
+                    "test-thermostat": {"on": True, "mode": ENERGY_SAVER_MODE}
+                }
+            }
+        }
+    }
+
+    assert set(entity.hvac_modes) == {HVACMode.OFF, HVACMode.AUTO}
+    assert entity.hvac_mode == HVACMode.AUTO
+
+    asyncio.run(entity.async_set_hvac_mode(HVACMode.AUTO))
+
+    client.async_set_thermostat.assert_awaited_once_with(
+        "test-device",
+        "test-thermostat",
+        on=True,
+        mode=ENERGY_SAVER_MODE,
+    )
+
+
+def test_native_auto_token_takes_precedence() -> None:
+    """Keep using native AUTO when the appliance supports both modes."""
+    entity, client = _create_entity(ENERGY_SAVER_MODE, NATIVE_AUTO_MODE)
+
+    asyncio.run(entity.async_set_hvac_mode(HVACMode.AUTO))
+
+    client.async_set_thermostat.assert_awaited_once_with(
+        "test-device",
+        "test-thermostat",
+        on=True,
+        mode=NATIVE_AUTO_MODE,
+    )
+
+
+def test_hvac_action_uses_power_draw_for_compressor_activity() -> None:
+    """Report cooling only while power draw indicates compressor activity."""
+    cool_mode = "cloud.smarthq.type.thermostatmode.cool"
+    entity, _ = _create_entity(cool_mode)
+
+    _set_thermostat_state(entity, mode=cool_mode, power=500)
+    assert entity.hvac_action == HVACAction.COOLING
+
+    _set_thermostat_state(entity, mode=cool_mode, power=50)
+    assert entity.hvac_action == HVACAction.IDLE
+
+
+def test_hvac_action_reports_off_and_fan_only() -> None:
+    """Report direct activity states without compressor inference."""
+    fan_mode = "cloud.smarthq.type.thermostatmode.fanonly"
+    entity, _ = _create_entity(fan_mode)
+
+    _set_thermostat_state(entity, mode=fan_mode)
+    assert entity.hvac_action == HVACAction.FAN
+
+    _set_thermostat_state(entity, on=False, mode=fan_mode)
+    assert entity.hvac_action == HVACAction.OFF


### PR DESCRIPTION
## Summary

- expose SmartHQ `cool.energysaver` as Home Assistant `AUTO` instead of collapsing it into `COOL`
- send the Energy Saver token when `AUTO` is selected on an eco-only appliance, while preserving the native AUTO token on devices that support it
- report `hvac_action` from the sibling instantaneous-power service, with temperature/setpoint fallback when power data is unavailable
- add regression coverage for eco mode selection and cooling, idle, fan, and off activity

## Why

Energy Saver is a distinct selectable mode on GE window AC units, but the integration currently maps it to `COOL`. That hides the mode in Home Assistant, and selecting `AUTO` sends `cloud.smarthq.type.thermostatmode.auto`, which eco-only appliances do not support.

The thermostat service also has no explicit compressor-running field. The sibling `power.usage` service provides a useful activity signal: observed fan-only draw is roughly 30-70 W, while compressor operation is several hundred watts. This change uses 120 W as the boundary and falls back to ambient temperature versus the active setpoint.

## Testing

- `python -m pytest -q custom_components/smarthq/tests/test_climate.py` (4 passed)
- `python -m compileall -q custom_components/smarthq`