### PR TITLE
Fix stale instantaneous power after thermostat turns off

### DIFF
--- a/custom_components/smarthq/tests/test_ws_client.py
+++ b/custom_components/smarthq/tests/test_ws_client.py
@@ -1,0 +1,40 @@
+"""Tests for SmartHQ WebSocket state handling."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.smarthq.service_registry import POWER_USAGE_SERVICE, THERMOSTAT_SERVICE
+from custom_components.smarthq.ws_client import SmartHQWebsocket
+
+
+@pytest.mark.parametrize(("thermostat_on", "expected_power"), [(False, 0), (True, 708)])
+async def test_thermostat_update_reconciles_instantaneous_power(thermostat_on: bool, expected_power: int) -> None:
+    """Clear stale power only when the thermostat explicitly turns off."""
+    device_id = "test-device"
+    store = {
+        device_id: {
+            "snapshot": {
+                "services": {
+                    "power": {
+                        "serviceType": POWER_USAGE_SERVICE,
+                        "instantaneousPower": 708,
+                    }
+                }
+            }
+        }
+    }
+    websocket = SmartHQWebsocket(MagicMock(), api=MagicMock(), device_ids=[device_id], store=store)
+    payload = {
+        "kind": "pubsub#service",
+        "deviceId": device_id,
+        "serviceId": "thermostat",
+        "serviceType": THERMOSTAT_SERVICE,
+        "domainType": "cloud.smarthq.domain.thermostat",
+        "state": {"on": thermostat_on},
+    }
+
+    with patch("custom_components.smarthq.ws_client.async_dispatcher_send"):
+        await websocket._on_message(payload)
+
+    assert store[device_id]["snapshot"]["services"]["power"]["instantaneousPower"] == expected_power

--- a/custom_components/smarthq/ws_client.py
+++ b/custom_components/smarthq/ws_client.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .api import SmartHQApi
 from .dispatcher import SIGNAL_DEVICE_UPDATED
+from .service_registry import POWER_USAGE_SERVICE, THERMOSTAT_SERVICE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1468,6 +1469,14 @@ class SmartHQWebsocket:
                 base = dict(cur_services.get(sid) or {})
                 base.update(st)
                 cur_services[sid] = base
+
+            if any(
+                st.get("serviceType") == THERMOSTAT_SERVICE and st.get("on") is False
+                for st in svc_states.values()
+            ):
+                for service_state in cur_services.values():
+                    if service_state.get("serviceType") == POWER_USAGE_SERVICE:
+                        service_state["instantaneousPower"] = 0
             
             # Update index
             cur_index = snap.setdefault("index", {})


### PR DESCRIPTION
## Summary

- reset cached `instantaneousPower` when a thermostat explicitly reports `on: false`
- prevent the last compressor wattage from persisting when SmartHQ omits the sibling power service from a partial WebSocket update
- preserve backend power readings for thermostat-on updates
- add regression coverage for both paths

## Background

WebSocket service updates are merged into the existing snapshot. When an off update contains only the thermostat service, an older `cloud.smarthq.service.power.usage` value remains cached and Home Assistant can continue showing values such as 708 W while the appliance is off.

## Testing

```console
PYTHONPATH="$PWD" uv run --python 3.14 --managed-python --with "homeassistant==2026.7.2" --with pytest --with pytest-homeassistant-custom-component pytest -q -p no:cacheprovider --asyncio-mode=auto custom_components/smarthq/tests/test_ws_client.py
```

Result: `2 passed`.