### PR TITLE
Fix NameError in number platform setup (undefined enabled_default)

### DIFF
--- a/custom_components/smarthq/number.py
+++ b/custom_components/smarthq/number.py
@@ -162,7 +162,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     dev_name=dev_name, label=label,
                     min_val=min_val, max_val=max_val, unit=ha_unit,
                     unique_id=make_unique_id(device_id, service_id, "int_number"),
-                    enabled_default=enabled_default,
+                    enabled_default=True,
                     entity_category=None,
                     warm_mode_only=False,
                 ))


### PR DESCRIPTION
Fix for enabled_default number issue.

The integer-number branch of `async_setup_entry` passed an undefined local `enabled_default`, raising `NameError` and aborting setup of the entire SmartHQ `number` platform. `SmartHQIntegerNumber.__init__` already defaults `enabled_default=True`, so pass the literal to preserve the intended behavior.