### PR TITLE
chore: bump manifest version to 1.2.4

### DIFF
--- a/custom_components/smarthq/manifest.json
+++ b/custom_components/smarthq/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/geappliances/geappliances-smarthq-integration/issues",
   "loggers": ["custom_components.smarthq"],
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "1.2.3"
+  "version": "1.2.4"
 }


### PR DESCRIPTION
Single-line change: `"version": "1.2.3"` → `"version": "1.2.4"` in `manifest.json`. Required for HACS to surface the v1.2.4 update notification.