### PR TITLE
fix(switch): dedup TOGGLE_SERVICE switches by (serviceType, domainType)

### DIFF
--- a/custom_components/smarthq/switch.py
+++ b/custom_components/smarthq/switch.py
@@ -152,6 +152,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
             # ── Route to entity builder based on serviceType ──
             if stype == TOGGLE_SERVICE and CMD_TOGGLE_SET in cmds:
+                # Skip if this device already has a toggle switch for this domain.
+                # Some devices expose the same domainType (e.g. controls.lock) as a
+                # separate toggle service instance per serviceDeviceType, which would
+                # otherwise create multiple identically-labeled switch entities
+                # (see MODE_SERVICE dedup below for the same class of issue).
+                dedup_key = (stype, dom)
+                if dedup_key in seen_switch_domains:
+                    _LOGGER.debug(
+                        "[SWITCH] Skipping duplicate toggle switch for device=%s domain=%s svc=%s",
+                        device_id, dom, service_id,
+                    )
+                    continue
+                seen_switch_domains.add(dedup_key)
                 label, icon = _label_for_toggle(dom, svc.get("serviceDeviceType") or "")
                 entities.append(SmartHQToggleSwitch(
                     hass=hass, entry=entry, ws=ws,


### PR DESCRIPTION
## Problem
Fixes #35 — `Control Lock` switch appears twice for a dishwasher (CDT875P4N8W2).

## Root Cause
`switch.py`'s `async_setup_entry` builds a switch entity for every service matching `TOGGLE_SERVICE` + `CMD_TOGGLE_SET`, with no per-device dedup. If the same lock/override `domainType` is exposed as more than one toggle service instance (e.g. once per `serviceDeviceType`), each instance produces its own `SmartHQToggleSwitch`, and `_label_for_toggle()` labels both identically as "Control Lock" — resulting in two visually-identical switches in HA.

The `MODE_SERVICE` branch right below already guards against this exact class of duplication (see its existing comment about the Smoker Light State Service appearing per `smoker`/`light` serviceDeviceType), but the `TOGGLE_SERVICE` branch was missing the same guard.

## Fix
Apply the same `(serviceType, domainType)` dedup key/set used by `MODE_SERVICE` to the `TOGGLE_SERVICE` branch, so only the first toggle service per domain is exposed as a switch per device.

## Testing
Verified no syntax/type errors. No behavior change for devices with only one toggle service per domain (the common case).