### PR TITLE
feat(binary_sensor): expose read-only door toggle services as door sensors

### DIFF
--- a/custom_components/smarthq/binary_sensor.py
+++ b/custom_components/smarthq/binary_sensor.py
@@ -23,6 +23,7 @@ from .service_registry import (
     TOGGLE_SERVICE,
     CMD_TOGGLE_SET,
     FILTER_STATUS_DOMAIN,
+    DOOR_DOMAIN,
     STOPWATCH_SERVICE,
     ENHANCEDFEATURE_SERVICE,
     DISHWASHER_STATE_SERVICE,
@@ -274,6 +275,19 @@ async def async_setup_entry(
                     # of skipping it (switch.py only creates a switch when
                     # CMD_TOGGLE_SET is present, so this is mutually exclusive).
                     dom = svc.get("domainType") or ""
+                    # Read-only toggle on the door domain: some appliances report
+                    # door state this way rather than via DOOR_SERVICE (e.g. the
+                    # Fisher & Paykel dishwasher publishes cloud.smarthq.domain.door
+                    # as a toggle with no supportedCommands). Without this it is
+                    # dropped by both platforms and the door state is never exposed.
+                    if CMD_TOGGLE_SET not in cmds and dom == DOOR_DOMAIN:
+                        uid = make_unique_id(device_id, service_id, "door")
+                        if uid not in created:
+                            created.add(uid)
+                            coord_entities.append(
+                                SmartHQDoorBinarySensor(hass, entry, device_id, service_id, "Door", uid)
+                            )
+                        continue
                     if CMD_TOGGLE_SET in cmds or dom != FILTER_STATUS_DOMAIN:
                         continue
                     uid = make_unique_id(device_id, service_id, "filter_status")
@@ -487,7 +501,16 @@ class SmartHQDoorBinarySensor(BinarySensorEntity):
     def is_on(self) -> bool:
         """Return True when door is open."""
         st = self._get_state()
-        raw = st.get("doorState") or st.get("state") or st.get("open") or ""
+        raw = st.get("doorState") or st.get("state") or st.get("open")
+        if raw is None:
+            # Toggle-shaped door services carry {"on": bool}. Checked last so a
+            # genuine doorState always wins: ws_client normalises `enabled` and
+            # `mode` into `on` for every service, so `on` may be present but
+            # unrelated to the door.
+            on = st.get("on")
+            if isinstance(on, bool):
+                return on
+            raw = ""
         if isinstance(raw, bool):
             return raw
         return str(raw).lower() in {"open", "true", "1"}

--- a/custom_components/smarthq/service_registry.py
+++ b/custom_components/smarthq/service_registry.py
@@ -85,6 +85,7 @@ DISHWASHER_FAVORITES_V1_SERVICE = "cloud.smarthq.service.dishwasher.favorites.v1
 # ---------------------------------------------------------------------------
 
 FILTER_STATUS_DOMAIN = "cloud.smarthq.domain.filter.status"
+DOOR_DOMAIN = "cloud.smarthq.domain.door"
 
 # ---------------------------------------------------------------------------
 # Command type constants

--- a/custom_components/smarthq/tests/test_binary_sensor.py
+++ b/custom_components/smarthq/tests/test_binary_sensor.py
@@ -1,0 +1,57 @@
+"""Tests for the SmartHQ binary_sensor platform."""
+
+from unittest.mock import MagicMock
+
+from custom_components.smarthq.binary_sensor import SmartHQDoorBinarySensor
+from custom_components.smarthq.const import DOMAIN
+
+DEVICE_ID = "test-device"
+SERVICE_ID = "test-door"
+
+
+def _create_door_entity(state: dict) -> SmartHQDoorBinarySensor:
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"test-entry": {"store": {DEVICE_ID: {"snapshot": {"services": {SERVICE_ID: state}}}}}}}
+    entry = MagicMock()
+    entry.entry_id = "test-entry"
+    return SmartHQDoorBinarySensor(hass, entry, DEVICE_ID, SERVICE_ID, "Door", "test-door-uid")
+
+
+def test_door_state_string_open():
+    """A DOOR_SERVICE reporting doorState="open" is on."""
+    assert _create_door_entity({"doorState": "open"}).is_on is True
+
+
+def test_door_state_string_closed():
+    """A DOOR_SERVICE reporting doorState="closed" is off."""
+    assert _create_door_entity({"doorState": "closed"}).is_on is False
+
+
+def test_toggle_shaped_door_open():
+    """A read-only toggle door service reporting {"on": True} is on."""
+    assert _create_door_entity({"on": True}).is_on is True
+
+
+def test_toggle_shaped_door_closed():
+    """A read-only toggle door service reporting {"on": False} is off.
+
+    Regression guard: `on` must be read explicitly. Falling through to the
+    string branch would coerce False to "" and report the door closed for
+    both states, which is indistinguishable from a working sensor.
+    """
+    assert _create_door_entity({"on": False}).is_on is False
+
+
+def test_door_state_wins_over_normalised_on():
+    """An explicit doorState takes precedence over a normalised `on` flag.
+
+    ws_client normalises `enabled`/`mode` into `on` for every service, so `on`
+    may be present on a DOOR_SERVICE without describing the door.
+    """
+    assert _create_door_entity({"doorState": "open", "on": False}).is_on is True
+
+
+def test_unavailable_when_service_missing():
+    """An entity with no service state in the store is unavailable."""
+    entity = _create_door_entity({})
+    assert entity.available is False


### PR DESCRIPTION
Fixes #38

### What

Exposes door state for appliances that publish it as a read-only `TOGGLE_SERVICE` on `cloud.smarthq.domain.door` instead of via `DOOR_SERVICE`.

Two changes in one logical fix:

1. **`binary_sensor.py`** builds a `SmartHQDoorBinarySensor` for a read-only toggle on the door domain, reusing the existing entity class. Previously the service was dropped by both platforms — `switch.py` skips it for lacking `CMD_TOGGLE_SET`, and the read-only-toggle branch here only handles `FILTER_STATUS_DOMAIN`.

2. **`SmartHQDoorBinarySensor.is_on`** learns the toggle shape. It previously read only `doorState` / `state` / `open`, so `{"on": bool}` fell through to `""` and reported the door permanently closed. The new key is checked **last**, so an explicit `doorState` always wins — `ws_client` normalises `enabled` and `mode` into `on` for every service, so `on` can be present on a `DOOR_SERVICE` without describing the door.

`DOOR_DOMAIN` is added to `service_registry.py` alongside `FILTER_STATUS_DOMAIN`.

### Testing

**Unit tests** — adds `tests/test_binary_sensor.py` (6 tests) covering both service shapes, the precedence rule, and unavailability when the service is missing from the store. `test_toggle_shaped_door_open` fails on `main` and passes with change (1), so it is a real regression guard rather than a restatement of current behaviour.

**Live appliance** — verified on a Fisher & Paykel dishwasher (model `DW60UT4I2`, reported by the API as `AATD`): a real open/close was logged as `on` then `off` 13 seconds apart, confirming the state is websocket-pushed and that both edges are captured.

**Pre-existing failures** — `test_ws_client.py::test_thermostat_update_reconciles_instantaneous_power` (both parametrisations) fails, and `test_config_flow.py` / `test_init.py` error, on unmodified `main` in my environment. Unchanged by this PR; flagging them so they are not mistaken for fallout.

### Notes

I can only confirm the one appliance I own. Given the service shape is generic, other Fisher & Paykel models — and possibly GE models exposing a door the same way — likely benefit, but I have not verified that.

