### PR TITLE
Fix swing mode feature in climate.py

### DIFF
--- a/custom_components/smarthq/climate.py
+++ b/custom_components/smarthq/climate.py
@@ -226,12 +226,18 @@ class SmartHQThermostatClimate(ClimateEntity):
 
         # Build supported features
         features = ClimateEntityFeature.TARGET_TEMPERATURE
+
         if fan_modes:
             features |= ClimateEntityFeature.FAN_MODE
+
         if svc_config.get("supportsSwing"):
             features |= ClimateEntityFeature.SWING_MODE
-        self._attr_supported_features = features
+            self._attr_swing_modes = ["off", "on"]
+        else:
+            self._attr_swing_modes = []
 
+        self._attr_supported_features = features
+        
     def _get_state(self) -> dict:
         store = _store(self.hass, self._entry)
         snap = (store.get(self._device_id) or {}).get("snapshot") or {}


### PR DESCRIPTION
Fixes climate entity initialization for thermostat devices with swing support enabled.

When `supportsSwing` is present, `ClimateEntityFeature.SWING_MODE` is added but `_attr_swing_modes` is never initialized. Home Assistant then raises an AttributeError during entity creation, preventing the climate entity from loading.

Fix - Initialize `_attr_swing_modes` when swing support is enabled and provide an empty list otherwise.

Tested with a Haier SmartHQ-connected air conditioner (`cloud.smarthq.device.airconditioner`).
(AD140S2SH5FA, GE_MODULE_5898 Wi‑Fi module, SmartHQ integration.)

Before fix:
- Climate entity failed to load
- AttributeError raised during startup

After fix:
- Climate entity created successfully
- HVAC mode control works
- Temperature control works
- Fan mode control works
- Swing mode control available