### PR TITLE
feat(hotwater): beverage temperature presets + fix Celsius setpoint rounding bug

### DIFF
--- a/custom_components/smarthq/button.py
+++ b/custom_components/smarthq/button.py
@@ -5,6 +5,7 @@ Entity registration is driven entirely by coordinator.data[device_id]["item"]["s
 Service → entity mapping:
   trigger                          → SmartHQTriggerButton   (trigger.do)
   firmware.v1 + CMD_FIRMWARE_UPGRADE → SmartHQFirmwareUpgradeButton
+  temperature (refrigerator.hotwater) → SmartHQHotWaterPresetButton (Cocoa/Tea/Soup)
   coffeebrewer.v1/.v2              → SmartHQCoffeeBrewerButton (start + stop)
   cooking.mode.v1 (with food doms) → SmartHQStartCookingButton (send pending params)
 """
@@ -20,11 +21,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, MANUFACTURER, DEFAULT_NAME
+from .const import DOMAIN, MANUFACTURER, DEFAULT_NAME, sdev_prefix
 from .dispatcher import SIGNAL_DEVICE_UPDATED
 from .service_registry import (
     TRIGGER_SERVICE,
     FIRMWARE_SERVICE,
+    TEMPERATURE_SERVICE,
+    CMD_TEMPERATURE_SET,
     COFFEEBREWER_V1_SERVICE,
     COFFEEBREWER_V2_SERVICE,
     COOKING_MODE_SERVICE,
@@ -198,6 +201,30 @@ async def async_setup_entry(hass, entry, async_add_entities):
             elif stype == FIRMWARE_SERVICE:
                 _LOGGER.debug("[BUTTON] Blocking firmware trigger for %s", device_id[:8])
                 continue
+
+            # ── refrigerator hot water: beverage temperature presets ────────
+            # There is no separate "start heating" command — sending
+            # temperature.set with the target fahrenheit value both sets the
+            # setpoint and starts heating (confirmed with the App team). These
+            # buttons are a shortcut for the app's Cocoa/Tea/Soup quick-picks.
+            elif (
+                stype == TEMPERATURE_SERVICE
+                and CMD_TEMPERATURE_SET in cmds
+                and "hotwater" in (svc.get("serviceDeviceType") or "")
+            ):
+                prefix = sdev_prefix(svc.get("serviceDeviceType") or "") or "Hot Water"
+                for preset_name, preset_f, icon in (
+                    ("Cocoa", 150, "mdi:coffee"),
+                    ("Tea", 170, "mdi:tea"),
+                    ("Soup", 185, "mdi:pot-steam"),
+                ):
+                    entities.append(SmartHQHotWaterPresetButton(
+                        hass=hass, entry=entry, client=client,
+                        device_id=device_id, service_id=service_id,
+                        dev_name=dev_name, label=f"{prefix} {preset_name} Preset",
+                        fahrenheit=preset_f, icon=icon,
+                        unique_id=make_unique_id(device_id, service_id, f"hotwater_preset_{preset_name.lower()}"),
+                    ))
 
             # ── coffee brewer start/stop ────────────────────────────────────
             elif stype in (COFFEEBREWER_V1_SERVICE, COFFEEBREWER_V2_SERVICE):
@@ -389,6 +416,42 @@ class SmartHQTriggerButton(_SmartHQButtonBase):
             _LOGGER.info("[TRIGGER] ✓ Sent trigger.do for %s", self._attr_name)
         except Exception as exc:
             _LOGGER.error("[TRIGGER] ✗ Failed for %s: %s", self._attr_name, exc)
+
+
+class SmartHQHotWaterPresetButton(_SmartHQButtonBase):
+    """Button that sets the refrigerator hot water dispenser to a fixed preset.
+
+    Mirrors the SmartHQ app's Cocoa/Tea/Soup quick-picks. There is no
+    separate "start heating" command — temperature.set with the target
+    fahrenheit value both stores the setpoint and starts heating.
+    """
+
+    def __init__(self, hass, entry, client, device_id, service_id,
+                 dev_name, label, fahrenheit: int, icon: str, unique_id):
+        super().__init__(hass, entry, device_id, dev_name, unique_id)
+        self._client = client
+        self._service_id = service_id
+        self._fahrenheit = fahrenheit
+        self._attr_name = f"{dev_name} {label}"
+        self._attr_icon = icon
+
+    async def async_press(self) -> None:
+        client = self._client or _bucket(self.hass, self._entry).get("client")
+        if not client:
+            _LOGGER.error("[HOTWATER_PRESET] WebSocket client not available")
+            return
+        snap = _snapshot_for(self.hass, self._entry, self._device_id)
+        svc = (snap.get("services") or {}).get(self._service_id) or {}
+        try:
+            await client.async_send_service_command(
+                device_id=self._device_id,
+                service=svc,
+                command_type=CMD_TEMPERATURE_SET,
+                command_params={"fahrenheit": self._fahrenheit},
+            )
+            _LOGGER.info("[HOTWATER_PRESET] ✓ Sent %s°F for %s", self._fahrenheit, self._attr_name)
+        except Exception as exc:
+            _LOGGER.error("[HOTWATER_PRESET] ✗ Failed for %s: %s", self._attr_name, exc)
 
 
 class SmartHQFirmwareUpgradeButton(_SmartHQButtonBase):

--- a/custom_components/smarthq/select.py
+++ b/custom_components/smarthq/select.py
@@ -1553,10 +1553,13 @@ class SmartHQTemperatureSetpointSelect(SelectEntity):
             return round(f)
         return round((f - 32) * 5 / 9)
 
-    def _display_to_f(self, v: int) -> float:
+    def _display_to_f(self, v: int) -> int:
+        # Always send a whole-degree Fahrenheit value — the API/appliance
+        # firmware expects an integer (e.g. 150), not a converted decimal
+        # (e.g. 134.6), which the device silently ignores.
         if self._is_f():
-            return float(v)
-        return round(v * 9 / 5 + 32, 1)
+            return v
+        return round(v * 9 / 5 + 32)
 
     def _display_min(self) -> int:
         return self._f_to_display(self._min_f)

--- a/custom_components/smarthq/service_registry.py
+++ b/custom_components/smarthq/service_registry.py
@@ -342,10 +342,10 @@ SERVICE_MAPPING: dict[str, dict] = {
         "handler": "StandardDryerRackBinarySensor",
     },
 
-    # sensor (read-only)
+    # sensor (read-only) / button (hot water beverage presets, see button.py)
     TEMPERATURE_SERVICE: {
         "type": "standard",
-        "platform": ["sensor", "select"],
+        "platform": ["sensor", "select", "button"],
         "handler": "StandardTemperature",
     },
     INTEGER_SERVICE: {


### PR DESCRIPTION
## What
1. **New: Hot Water beverage presets** — adds `SmartHQHotWaterPresetButton` (Cocoa 150°F / Tea 170°F / Soup 185°F) for the refrigerator's hot water dispenser, mirroring the SmartHQ app's quick-pick buttons.
   - Confirmed with the SmartHQ App team: there is no separate "start heating" command — sending `temperature.set` with the target `fahrenheit` value both sets the setpoint **and** starts heating. So no new trigger/command was needed, just a shortcut to the existing command with fixed preset values.
2. **Fix: fractional Fahrenheit sent when device is displayed in Celsius** — `SmartHQTemperatureSetpointSelect._display_to_f()` was rounding to 1 decimal place (e.g. selecting 57°C sent `fahrenheit: 134.6`), which the appliance silently ignored (command accepted at the transport level, no physical effect). Root-caused from live logs. Now always rounds to a whole degree, matching the integer-only payload the app itself sends (e.g. `150`). This affects every writable temperature setpoint using this select (hot water, fridge, freezer, etc.), not just hot water.

## Verified
- Reproduced the fractional-value bug from HA logs (`fahrenheit=134.6` for a 57°C selection) before the fix.
- After the fix, tested the new preset buttons on a real Café Refrigerator — hot water heating starts correctly.

## How to use it
1. **Press button which you want to set**(Cocoa: 66°C, Tea: 77°C, Soup: 85°C), then Hot Water Setpoint is changed to the set temperature.
    
<img width="664" height="448" alt="image" src="https://github.com/user-attachments/assets/8f3773e3-bdf5-491f-a5e3-af1d12af337c" />

2. You can see "Heating Water..." in the refrigerator's display, when hot water is ready, you can see it in the display.
   
<img width="704" height="420" alt="image" src="https://github.com/user-attachments/assets/9f029b17-ef93-496d-a749-6f5da9940d93" />
<img width="782" height="470" alt="image" src="https://github.com/user-attachments/assets/08185234-62a7-4104-a7b6-576279b96f6a" />

3. For dispensing Hot Water, **press Hot Water button in the control panel**, then click the same button which you already clicked in Home Assistant.
<img width="662" height="371" alt="image" src="https://github.com/user-attachments/assets/aec92ce8-1327-4f25-8cfb-b2302e0c3d78" />

4. You can see "Ready" in the display, then you can use the knob of Hot Water(Red LED lighting) for dispensing Hot water.
<img width="1123" height="630" alt="image" src="https://github.com/user-attachments/assets/a98ede14-f638-454d-8ca9-bd2fa44599fe" />



