### PR TITLE
fix(climate): enforce AWCS08WWT minimum temperature

### DIFF
--- a/custom_components/smarthq/climate.py
+++ b/custom_components/smarthq/climate.py
@@ -46,6 +46,9 @@ _LOGGER = logging.getLogger(__name__)
 _COMPRESSOR_POWER_THRESHOLD_W = 120.0
 _ENERGY_SAVER_MODE = "cloud.smarthq.type.thermostatmode.cool.energysaver"
 _NATIVE_AUTO_MODE = "cloud.smarthq.type.thermostatmode.auto"
+_MODEL_MINIMUM_COOL_TEMPERATURES = {
+    "AWCS08WWT": 64.0,
+}
 
 # ---------------------------------------------------------------------------
 # SmartHQ → HA HVAC mode mapping
@@ -139,7 +142,9 @@ async def async_setup_entry(
     existing_uids: set = set()
 
     for device_id, dev_data in coordinator.data.items():
-        dev_name = (dev_data.get("info") or {}).get("nickname") or DEFAULT_NAME
+        dev_info = dev_data.get("info") or {}
+        dev_name = dev_info.get("nickname") or DEFAULT_NAME
+        dev_model = dev_info.get("model") or dev_info.get("deviceType")
         item = dev_data.get("item") or {}
         for svc in (item.get("services") or []):
             stype = svc.get("serviceType") or ""
@@ -167,6 +172,7 @@ async def async_setup_entry(
                         dev_name=dev_name,
                         svc_config=svc.get("config") or {},
                         unique_id=uid,
+                        dev_model=dev_model,
                     ))
 
     _LOGGER.info("[CLIMATE] Registering %d climate entities", len(entities))
@@ -195,6 +201,7 @@ class SmartHQThermostatClimate(ClimateEntity):
         dev_name: str,
         svc_config: dict,
         unique_id: str,
+        dev_model: str | None = None,
     ) -> None:
         self.hass = hass
         self._entry = entry
@@ -220,7 +227,15 @@ class SmartHQThermostatClimate(ClimateEntity):
         self._attr_fan_modes = fan_modes or None
 
         # Temperature range
-        self._attr_min_temp = svc_config.get("coolFahrenheitMinimum") or svc_config.get("heatFahrenheitMinimum") or 60.0
+        advertised_min_temp = (
+            svc_config.get("coolFahrenheitMinimum")
+            or svc_config.get("heatFahrenheitMinimum")
+            or 60.0
+        )
+        model_min_temp = _MODEL_MINIMUM_COOL_TEMPERATURES.get(
+            (dev_model or "").upper(), 0.0
+        )
+        self._attr_min_temp = max(float(advertised_min_temp), model_min_temp)
         self._attr_max_temp = svc_config.get("coolFahrenheitMaximum") or svc_config.get("heatFahrenheitMaximum") or 86.0
         self._attr_target_temperature_step = 1.0
 
@@ -391,6 +406,7 @@ class SmartHQThermostatClimate(ClimateEntity):
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
+        temp = max(float(temp), self.min_temp)
         mode = self.hvac_mode
         params: dict = {}
         if mode == HVACMode.HEAT:

--- a/custom_components/smarthq/tests/test_climate.py
+++ b/custom_components/smarthq/tests/test_climate.py
@@ -13,12 +13,19 @@ ENERGY_SAVER_MODE = "cloud.smarthq.type.thermostatmode.cool.energysaver"
 NATIVE_AUTO_MODE = "cloud.smarthq.type.thermostatmode.auto"
 
 
-def _create_entity(*supported_modes: str) -> tuple[SmartHQThermostatClimate, AsyncMock]:
+def _create_entity(
+    *supported_modes: str,
+    device_model: str | None = None,
+    cool_minimum: float | None = None,
+) -> tuple[SmartHQThermostatClimate, AsyncMock]:
     hass = MagicMock()
     hass.data = {DOMAIN: {"test-entry": {"store": {}}}}
     entry = MagicMock()
     entry.entry_id = "test-entry"
     client = AsyncMock()
+    svc_config = {"supportedModes": list(supported_modes)}
+    if cool_minimum is not None:
+        svc_config["coolFahrenheitMinimum"] = cool_minimum
     entity = SmartHQThermostatClimate(
         hass=hass,
         entry=entry,
@@ -26,8 +33,9 @@ def _create_entity(*supported_modes: str) -> tuple[SmartHQThermostatClimate, Asy
         device_id="test-device",
         service_id="test-thermostat",
         dev_name="Test AC",
-        svc_config={"supportedModes": list(supported_modes)},
+        svc_config=svc_config,
         unique_id="test-climate",
+        dev_model=device_model,
     )
     return entity, client
 
@@ -112,3 +120,24 @@ def test_hvac_action_reports_off_and_fan_only() -> None:
 
     _set_thermostat_state(entity, on=False, mode=fan_mode)
     assert entity.hvac_action == HVACAction.OFF
+
+
+def test_awcs08wwt_enforces_effective_64f_minimum() -> None:
+    """Clamp the AWCS08WWT's incorrectly advertised 62 F minimum to 64 F."""
+    cool_mode = "cloud.smarthq.type.thermostatmode.cool"
+    entity, client = _create_entity(
+        cool_mode,
+        device_model="AWCS08WWT",
+        cool_minimum=62,
+    )
+    _set_thermostat_state(entity, mode=cool_mode)
+
+    assert entity.min_temp == 64
+
+    asyncio.run(entity.async_set_temperature(temperature=62))
+
+    client.async_set_thermostat.assert_awaited_once_with(
+        "test-device",
+        "test-thermostat",
+        coolFahrenheit=64.0,
+    )


### PR DESCRIPTION
## Summary
- read the appliance model when creating thermostat climate entities
- override the AWCS08WWT minimum to 64 F when its service config advertises 62 F
- clamp outbound setpoint commands to the effective entity minimum
- add regression coverage for both the exposed minimum and command payload

## Context
The AWCS08WWT reports a 62 F minimum through `coolFahrenheitMinimum`, but the model does not accept setpoints below 64 F. Without a model-specific effective minimum, Home Assistant offers 62-63 F controls and forwards commands the appliance cannot honor. Other models continue to use their advertised minimum.

## Testing
Tested with Home Assistant 2026.8.1 on Python 3.14.4:

```text
7 passed, 1 unrelated Home Assistant deprecation warning
```

Focused command:

```bash
python -m pytest -q -p no:cacheprovider --asyncio-mode=auto custom_components/smarthq/tests/test_climate.py custom_components/smarthq/tests/test_ws_client.py
```