### PR TITLE
fix(sensor): restore entity names + fix Source1/Source2 sensor duplication

### DIFF
--- a/custom_components/smarthq/sensor.py
+++ b/custom_components/smarthq/sensor.py
@@ -1247,10 +1247,12 @@ _STANDARD_SENSOR_SPECS: dict[str, list[_SF]] = {
     # Keys match the live API field names (secondsRemaining/secondsElapsed, not
     # timeRemaining/timeElapsed) so this sensor actually receives data and so
     # its (service_id, key) pair lines up with the _DYN_KEYS entries below for
-    # dedup purposes (see #48 follow-up).
+    # dedup purposes (see #48 follow-up). Labels are pinned explicitly so the
+    # payload key can differ from the user-facing name (_camel_to_words(key)
+    # would otherwise render "Seconds Remaining").
     CYCLETIMER_SERVICE: [
-        _SF("secondsRemaining", "timer_remaining", "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
-        _SF("secondsElapsed",   "timer_elapsed",   "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
+        _SF("secondsRemaining", "timer_remaining", "S", dev_cls=SensorDeviceClass.DURATION, unit="s", label="Time Remaining"),
+        _SF("secondsElapsed",   "timer_elapsed",   "S", dev_cls=SensorDeviceClass.DURATION, unit="s", label="Time Elapsed"),
     ],
     # ── battery ────────────────────────────────────────────────────────────
     BATTERY_SERVICE: [

--- a/custom_components/smarthq/sensor.py
+++ b/custom_components/smarthq/sensor.py
@@ -463,7 +463,6 @@ class SmartHQSnapshotSensor(SensorEntity):
         )
         self._attr_unique_id = f"{DOMAIN}:{device_id}:sensor:{service_id}:{state_key}"
         self._attr_has_entity_name = True
-        self._attr_name = None
 
     def _get_service_meta(self):
         """Return (service_state, service_type, domain_type)."""
@@ -698,7 +697,6 @@ class SmartHQServiceSensor(SensorEntity):
             native_unit_of_measurement=unit,
             entity_category=entity_category,
         )
-        self._attr_name = None
         # Only set _attr_ when a value is given; None would shadow subclass properties.
         if device_class is not None:
             self._attr_device_class = device_class
@@ -1006,11 +1004,21 @@ _LAUNDRY_STATE_ICONS: dict[str, str] = {
 # Discovery
 # ---------------------------------------------------------------------------
 
-def _iter_dynamic_sensors(hass: HomeAssistant, entry: ConfigEntry, device_id: str) -> Iterable[SmartHQSnapshotSensor]:
+def _iter_dynamic_sensors(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_id: str,
+    exclude_pairs: Optional[set] = None,
+) -> Iterable[SmartHQSnapshotSensor]:
+    """exclude_pairs: (service_id, state_key) already created by Source 1 (see
+    async_setup_entry) -- several _DYN_KEYS entries below have no serviceType
+    restriction and would otherwise duplicate those sensors (see #48).
+    """
     snap = _snapshot_for(hass, entry, device_id)
     services: Dict[str, Dict[str, Any]] = snap.get("services") or {}
     if not services:
         return []
+    exclude_pairs = exclude_pairs or set()
 
     # Build sid -> (serviceType, domainType) directly from services_map so that
     # services sharing the same (stype, domain) but different serviceDeviceType
@@ -1146,7 +1154,7 @@ def _iter_dynamic_sensors(hass: HomeAssistant, entry: ConfigEntry, device_id: st
             continue
 
         pair = (sid, key)
-        if pair in added_pairs:
+        if pair in added_pairs or pair in exclude_pairs:
             continue
         result.append(
             SmartHQSnapshotSensor(
@@ -1196,7 +1204,7 @@ def _iter_dynamic_sensors(hass: HomeAssistant, entry: ConfigEntry, device_id: st
             continue
 
         pair = (sid, key)
-        if pair in added_pairs:
+        if pair in added_pairs or pair in exclude_pairs:
             continue
         result.append(
             SmartHQSnapshotSensor(
@@ -1536,6 +1544,7 @@ def _build_standard_sensors(
     dev_name: str,
     stype: str,
     existing_uids: set[str],
+    used_pairs: Optional[set] = None,
 ) -> list[SensorEntity]:
     """Create sensor entities for a standard (data-driven) serviceType."""
     result: list[SensorEntity] = []
@@ -1567,6 +1576,8 @@ def _build_standard_sensors(
             )
         result.append(entity)
         existing_uids.add(uid)
+        if used_pairs is not None:
+            used_pairs.add((service_id, f.key))
     return result
 
 
@@ -1580,6 +1591,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
        that use device-specific state keys outside the generic service schema.
     """
     entities: List[SensorEntity] = []
+    # (service_id, state_key) pairs Source 1 has produced, so the generic
+    # (no serviceType restriction) _DYN_KEYS entries in Source 2 below don't
+    # recreate them under a different unique_id format (see #48).
+    used_pairs: set = set()
 
     # ── Source 1: coordinator service-based sensors ───────────────────────────
     bucket = hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}
@@ -1637,6 +1652,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                             label, uid,
                         ))
                         existing_uids.add(uid)
+                        used_pairs.add((service_id, "fahrenheit"))
 
                 # ── integer sensor (read-only) ──────────────────────────────
                 elif stype == INTEGER_SERVICE and CMD_INTEGER_SET not in cmds:
@@ -1652,6 +1668,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                             translation_key=_make_translation_key(label_base),
                         ))
                         existing_uids.add(uid)
+                        used_pairs.add((service_id, "value"))
 
                 # ── meter sensor ────────────────────────────────────────────
                 elif stype == METER_SERVICE:
@@ -1692,6 +1709,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                             translation_key=_make_translation_key(label_base),
                         ))
                         existing_uids.add(uid)
+                        used_pairs.add((service_id, "value"))
 
                 # ── string sensor ───────────────────────────────────────────
                 elif stype == STRING_SERVICE and CMD_STRING_SET not in cmds:
@@ -1711,6 +1729,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 elif stype in _STANDARD_SENSOR_SPECS:
                     entities.extend(_build_standard_sensors(
                         hass, entry, device_id, service_id, dev_name, stype, existing_uids,
+                        used_pairs,
                     ))
 
 
@@ -1720,7 +1739,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     # state keys not represented by the generic service schema.
     snapshot_entities: List[SensorEntity] = []
     for did in list(_store(hass, entry).keys()):
-        snapshot_entities.extend(list(_iter_dynamic_sensors(hass, entry, did)))
+        snapshot_entities.extend(list(_iter_dynamic_sensors(hass, entry, did, used_pairs)))
 
     all_entities = entities + snapshot_entities
     if all_entities:

--- a/custom_components/smarthq/sensor.py
+++ b/custom_components/smarthq/sensor.py
@@ -1244,9 +1244,13 @@ _STANDARD_SENSOR_SPECS: dict[str, list[_SF]] = {
     # Firmware version/status sensors are blocked; not exposed to users.
     # FIRMWARE_SERVICE: [...],
     # ── cycletimer ─────────────────────────────────────────────────────────
+    # Keys match the live API field names (secondsRemaining/secondsElapsed, not
+    # timeRemaining/timeElapsed) so this sensor actually receives data and so
+    # its (service_id, key) pair lines up with the _DYN_KEYS entries below for
+    # dedup purposes (see #48 follow-up).
     CYCLETIMER_SERVICE: [
-        _SF("timeRemaining", "timer_remaining", "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
-        _SF("timeElapsed",   "timer_elapsed",   "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
+        _SF("secondsRemaining", "timer_remaining", "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
+        _SF("secondsElapsed",   "timer_elapsed",   "S", dev_cls=SensorDeviceClass.DURATION, unit="s"),
     ],
     # ── battery ────────────────────────────────────────────────────────────
     BATTERY_SERVICE: [


### PR DESCRIPTION
Fixes #47, Fixes #48

## #47 — all sensor entities showed no name (regression from #43)
`SmartHQSnapshotSensor`/`SmartHQServiceSensor` set `_attr_has_entity_name = True` and then `_attr_name = None`. In Home Assistant, `_attr_name = None` combined with `has_entity_name = True` has a specific meaning: **this entity IS the device's main/primary entity**, so HA displays just the device name with no suffix — completely bypassing `entity_description.name`/`translation_key`. That's exactly the reported symptom (every sensor showing the bare device name, `original_name: None` in the registry).

Fix: stop setting `_attr_name` at all on these classes, so HA's naming resolution correctly falls through to `entity_description` (matching the intent of #43). This was my mistake in #43 — apologies for the regression, and thanks to @bombjamin for the precise report.

## #48 — duplicate sensors, un-suffixed `time_remaining` permanently unavailable
`async_setup_entry` builds sensors from two independent sources (coordinator services, and WS-snapshot `_iter_dynamic_sensors`), each deduped only against itself using a different `unique_id` format — so cross-source duplicates were never caught. Root cause exactly as diagnosed by @eikfour: four `_DYN_KEYS` entries (`secondsRemaining`, `runStatus`, `mode`, `value`) have no serviceType restriction and match laundry/generic services already covered by Source 1, producing a live `_2` twin while the original (built from `coordinator.data`, no WS push) stays permanently `unavailable`.

Implemented the more general of the two suggested fixes: Source 1 now threads the `(service_id, state_key)` pairs it already created into `_iter_dynamic_sensors`, so Source 2 skips anything already covered — this also protects against any future generic `_DYN_KEYS` entry reintroducing the same class of bug.

## Not included in this PR
`binary_sensor.py`'s alert-name collision (`binary_sensor.washer_alert_disabled` / `_2`, mentioned in #48) is a different mechanism (name derived from the alert's final segment only) — leaving that for a separate follow-up.

## Testing
No test suite currently covers `sensor.py`'s `async_setup_entry`; verified by code inspection and manual trace of the dedup logic against the exact key/spec collisions reported in both issues.