### PR TITLE
fix(sensor): use MEASUREMENT state_class for non-cumulative meter readings

### DIFF
--- a/custom_components/smarthq/sensor.py
+++ b/custom_components/smarthq/sensor.py
@@ -892,9 +892,14 @@ class SmartHQRawTempSensor(SmartHQServiceSensor):
 
 
 class SmartHQMeterSensor(SmartHQServiceSensor):
-    """Sensor for meter services (cumulative energy, water, etc.)."""
+    """Sensor for meter services (cumulative energy, water, etc.).
 
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    Only energy/water meterValues are actually cumulative; voltage/power/current
+    are instantaneous readings and must use MEASUREMENT, not TOTAL_INCREASING —
+    HA logs a state_class validation warning otherwise (#51).
+    """
+
+    _CUMULATIVE_DEVICE_CLASSES = frozenset({SensorDeviceClass.ENERGY, SensorDeviceClass.WATER})
 
     def __init__(
         self,
@@ -906,6 +911,11 @@ class SmartHQMeterSensor(SmartHQServiceSensor):
             hass, entry, device_id, service_id, dev_name,
             label, "meterValue", device_class, unit, unique_id,
             translation_key=translation_key,
+        )
+        self._attr_state_class = (
+            SensorStateClass.TOTAL_INCREASING
+            if device_class in self._CUMULATIVE_DEVICE_CLASSES
+            else SensorStateClass.MEASUREMENT
         )
 
     @property


### PR DESCRIPTION
Fixes #51

## Root cause
`SmartHQMeterSensor` hardcoded `_attr_state_class = SensorStateClass.TOTAL_INCREASING` for every `METER_SERVICE`, regardless of `device_class`. That's correct for energy/water (genuinely cumulative counters), but `METER_DOMAIN_UNIT_CLASS` also maps `voltage`/`power`/`current` domains through the same sensor class — all three are instantaneous readings, not running totals, so HA logs a state_class/device_class validation warning for them (reported for voltage specifically, but power/current would hit the same issue if/when they show up on a device).

## Fix
Only set `TOTAL_INCREASING` for `SensorDeviceClass.ENERGY`/`SensorDeviceClass.WATER`; everything else falls back to `MEASUREMENT`.

## Not addressed here
The reporter also noted the voltage meter always reads `0` on their water heater — that may be a real API/device data gap rather than an integration bug, and isn't something I can confirm without more devices to compare against. Leaving that as-is; happy to revisit if more data points come in.