### PR TITLE
fix(ws_client): keep retrying WS reconnect indefinitely, fix notification crash

### DIFF
--- a/custom_components/smarthq/ws_client.py
+++ b/custom_components/smarthq/ws_client.py
@@ -85,6 +85,7 @@ class SmartHQWebsocket:
         backoff = 1
         consecutive_failures = 0
         max_retries = 3
+        notified_failure = False
         
         while not self._stopped.is_set():
             try:
@@ -94,8 +95,16 @@ class SmartHQWebsocket:
                 async with self._session.ws_connect(endpoint, heartbeat=PING_IDLE_SECONDS) as ws:
                     self._ws = ws
                     _LOGGER.info("SmartHQ WS connected")
+                    if notified_failure:
+                        with contextlib.suppress(Exception):
+                            await self.hass.services.async_call(
+                                "persistent_notification", "dismiss",
+                                {"notification_id": "smarthq_websocket_failure"},
+                                blocking=False,
+                            )
                     backoff = 1
                     consecutive_failures = 0  # Reset on successful connection
+                    notified_failure = False
 
                     await self._subscribe_all(ws)
 
@@ -131,8 +140,8 @@ class SmartHQWebsocket:
                 break
             except Exception as e:
                 consecutive_failures += 1
-                
-                if consecutive_failures >= max_retries:
+
+                if consecutive_failures >= max_retries and not notified_failure:
                     error_msg = (
                         f"SmartHQ WebSocket connection failed {consecutive_failures} times.\n\n"
                         f"Last error: {str(e)}\n\n"
@@ -140,18 +149,20 @@ class SmartHQWebsocket:
                         f"- Internet connection\n"
                         f"- SmartHQ service status\n"
                         f"- OAuth2 credentials validity\n\n"
-                        f"The integration will stop attempting to reconnect. "
-                        f"Please restart Home Assistant or reload the SmartHQ integration to retry."
+                        f"The integration will keep retrying in the background with "
+                        f"increasing delay (up to {60}s). This notification will not repeat "
+                        f"until the connection recovers."
                     )
-                    
+
                     _LOGGER.error(
-                        "SmartHQ WS: Max retry limit (%d) reached. Stopping reconnection attempts. Error: %s",
-                        max_retries, e
+                        "SmartHQ WS: %d consecutive failures. Will keep retrying in the "
+                        "background. Last error: %s",
+                        consecutive_failures, e
                     )
-                    
-                    # Send persistent notification to Home Assistant UI
+
+                    # Send persistent notification to Home Assistant UI (once per outage)
                     try:
-                        await self._hass.services.async_call(
+                        await self.hass.services.async_call(
                             "persistent_notification", "create",
                             {
                                 "title": "⚠️ SmartHQ Connection Failed",
@@ -162,12 +173,12 @@ class SmartHQWebsocket:
                         )
                     except Exception as notification_error:
                         _LOGGER.error("Failed to create notification: %s", notification_error)
-                    
-                    break  # Stop reconnection loop
-                
+
+                    notified_failure = True
+
                 _LOGGER.warning(
-                    "WS error (attempt %d/%d): %s; reconnect in %s sec",
-                    consecutive_failures, max_retries, e, backoff
+                    "WS error (attempt %d): %s; reconnect in %s sec",
+                    consecutive_failures, e, backoff
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 60)


### PR DESCRIPTION
Partially addresses #49 -- fixes the two confirmed code bugs from that report.

## 1. Notification crash: `self._hass` typo
`_runner()` sets `self.hass = hass` in `__init__`, but the failure-notification path referenced `self._hass` (never set), so it crashed with `AttributeError` right when it was trying to tell the user something had gone wrong:
```
Failed to create notification: 'SmartHQWebsocket' object has no attribute '_hass'
```
Fixed to `self.hass`.

## 2. Permanent reconnect give-up after 3 failures
After `max_retries` (3) consecutive failures, the loop did `break`, permanently stopping all reconnection attempts until a manual integration reload/HA restart -- a rough failure mode for an always-on appliance integration, since any transient multi-minute connectivity blip (WiFi hiccup, DNS blip, etc., as in the reporter's own log) kills live WS updates indefinitely.

Now: send one notification per outage (using the fixed attribute), then keep retrying forever with the existing capped exponential backoff (max 60s) instead of stopping. The notification is auto-dismissed once the connection recovers, and won't repeat until a new outage starts.

## Not addressed in this PR (needs more data / likely device or cloud-side)
- The brightness-command-also-turns-on-fan side effect: no shared client-side logic exists between the hood's brightness/fan-speed `number` entities (each just sends an independent `integer.set`), so if setting one visibly affects the other, that's happening server/device-side, not in this integration.
- The `cloud.smarthq.outcome.deviceoffline` 412s and presence flapping ONLINE/OFFLINE within minutes: could reflect real device/cloud connectivity flakiness. Worth keeping an eye on separately once the reconnect fix is out, since a lot of the reported symptoms may have been downstream of the WS giving up permanently and never recovering.